### PR TITLE
Enable Windows targeting for non-Windows builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Guía para agentes
+
+Este repositorio contiene un proyecto multiplataforma basado en **.NET 10 Release Candidate 1** y **.NET MAUI**. El lenguaje principal es **C# 13** junto con vistas declarativas en **XAML**. Cuando agregues código nuevo:
+
+- Prefiere sintaxis moderna de C# (pattern matching, `using` implícitos, records, etc.) siempre que mantenga la legibilidad.
+- Mantén los textos visibles para las personas usuarias en español.
+- Asegúrate de que las ventanas principales funcionen en Windows, macOS (Mac Catalyst) e iOS.
+- Si dispones del SDK instalado en tu entorno, ejecuta `dotnet build` antes de finalizar tus cambios. Si no es posible, documenta la limitación en el resumen.
+- Evita introducir dependencias externas sin describir el motivo en la descripción del cambio.
+
+La estructura del proyecto se organiza a través de un único `HelloMaui.csproj` que apunta a los recursos compartidos y a las plataformas específicas.

--- a/HelloMaui.sln
+++ b/HelloMaui.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31611.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloMaui", "HelloMaui/HelloMaui.csproj", "{BA2D39AE-0057-45F7-9D26-4EA550B31B62}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{BA2D39AE-0057-45F7-9D26-4EA550B31B62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{BA2D39AE-0057-45F7-9D26-4EA550B31B62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{BA2D39AE-0057-45F7-9D26-4EA550B31B62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{BA2D39AE-0057-45F7-9D26-4EA550B31B62}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/HelloMaui/App.xaml
+++ b/HelloMaui/App.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HelloMaui.App">
+    <Application.Resources>
+        <ResourceDictionary>
+            <Color x:Key="BrandPrimary">#512BD4</Color>
+            <Style TargetType="Label">
+                <Setter Property="TextColor" Value="#1F1F1F" />
+            </Style>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/HelloMaui/App.xaml.cs
+++ b/HelloMaui/App.xaml.cs
@@ -1,0 +1,11 @@
+namespace HelloMaui;
+
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+
+        MainPage = new MainPage();
+    }
+}

--- a/HelloMaui/GlobalUsings.cs
+++ b/HelloMaui/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using Microsoft.Maui;
+global using Microsoft.Maui.Controls;
+global using Microsoft.Maui.Controls.Xaml;

--- a/HelloMaui/HelloMaui.csproj
+++ b/HelloMaui/HelloMaui.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.19041</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>HelloMaui</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ApplicationTitle>HelloMaui</ApplicationTitle>
+    <ApplicationId>com.companyname.hellomaui</ApplicationId>
+    <ApplicationIdGuid>E4DD3E27-7E8C-4427-A5DB-FDA31D79672F</ApplicationIdGuid>
+    <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
+    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
+    <DefaultLanguage>es-ES</DefaultLanguage>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) or $([MSBuild]::IsOSPlatform('Linux'))">
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MauiIcon Include="Resources\\AppIcon\\appicon.svg" />
+    <MauiSplashScreen Include="Resources\\Splash\\splash.svg" Color="#512BD4" BaseSize="256,256" />
+    <MauiImage Include="Resources\\Images\\**" LogicalName="%(Filename)%(Extension)" />
+    <MauiAsset Include="Resources\\Raw\\**" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.19041'">
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/HelloMaui/MainPage.xaml
+++ b/HelloMaui/MainPage.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HelloMaui.MainPage"
+             BackgroundColor="White">
+    <VerticalStackLayout Spacing="16"
+                         Padding="32"
+                         VerticalOptions="Center">
+        <Label Text="Hola mundo"
+               FontSize="36"
+               HorizontalOptions="Center"
+               TextColor="#1F1F1F" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/HelloMaui/MainPage.xaml.cs
+++ b/HelloMaui/MainPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace HelloMaui;
+
+public partial class MainPage : ContentPage
+{
+    public MainPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/HelloMaui/MauiProgram.cs
+++ b/HelloMaui/MauiProgram.cs
@@ -1,0 +1,13 @@
+namespace HelloMaui;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>();
+
+        return builder.Build();
+    }
+}

--- a/HelloMaui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/HelloMaui/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,0 +1,9 @@
+using Foundation;
+
+namespace HelloMaui;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/HelloMaui/Platforms/MacCatalyst/Info.plist
+++ b/HelloMaui/Platforms/MacCatalyst/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CFBundleDisplayName</key>
+<string>HelloMaui</string>
+<key>CFBundleIdentifier</key>
+<string>com.companyname.hellomaui</string>
+<key>CFBundleName</key>
+<string>HelloMaui</string>
+<key>LSMinimumSystemVersion</key>
+<string>14.0</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>Esta aplicación no utiliza el micrófono.</string>
+<key>NSCameraUsageDescription</key>
+<string>Esta aplicación no utiliza la cámara.</string>
+<key>UIDeviceFamily</key>
+<array>
+<integer>1</integer>
+<integer>2</integer>
+</array>
+</dict>
+</plist>

--- a/HelloMaui/Platforms/MacCatalyst/Program.cs
+++ b/HelloMaui/Platforms/MacCatalyst/Program.cs
@@ -1,0 +1,12 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace HelloMaui;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/HelloMaui/Platforms/Windows/App.xaml
+++ b/HelloMaui/Platforms/Windows/App.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Application
+    x:Class="HelloMaui.WinUI.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+</Application>

--- a/HelloMaui/Platforms/Windows/App.xaml.cs
+++ b/HelloMaui/Platforms/Windows/App.xaml.cs
@@ -1,0 +1,11 @@
+namespace HelloMaui.WinUI;
+
+public partial class App : MauiWinUIApplication
+{
+    public App()
+    {
+        InitializeComponent();
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/HelloMaui/Platforms/Windows/Assets/README.md
+++ b/HelloMaui/Platforms/Windows/Assets/README.md
@@ -1,0 +1,11 @@
+# Recursos generados
+
+Este directorio queda vacío en el control de versiones porque los iconos y pantallas de inicio de Windows se generan automáticamente a partir de los archivos vectoriales ubicados en `Resources/`.
+
+Para producir nuevamente los `.png` utilizados por el manifiesto de Windows ejecuta:
+
+```bash
+dotnet build -f net10.0-windows10.0.19041
+```
+
+El comando compila el proyecto y, durante el proceso, el pipeline de .NET MAUI crea los recursos en la carpeta de `obj` y los copia a la salida de publicación.

--- a/HelloMaui/Platforms/Windows/Package.appxmanifest
+++ b/HelloMaui/Platforms/Windows/Package.appxmanifest
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap mp">
+  <Identity Name="com.companyname.hellomaui" Publisher="CN=dotnet-maui" Version="1.0.0.0" />
+  <Properties>
+    <DisplayName>HelloMaui</DisplayName>
+    <PublisherDisplayName>dotnet-maui</PublisherDisplayName>
+    <Logo>Assets/StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.19041.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="App"
+                 Executable="$targetnametoken$.exe"
+                 EntryPoint="HelloMaui.WinUI.App">
+      <uap:VisualElements DisplayName="HelloMaui"
+                          Description="Aplicación de ejemplo .NET MAUI"
+                          BackgroundColor="transparent"
+                          Square150x150Logo="Assets/Square150x150Logo.png"
+                          Square44x44Logo="Assets/Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets/Wide310x150Logo.png" />
+        <uap:SplashScreen Image="Assets/SplashScreen.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+</Package>

--- a/HelloMaui/Platforms/iOS/AppDelegate.cs
+++ b/HelloMaui/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,9 @@
+using Foundation;
+
+namespace HelloMaui;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/HelloMaui/Platforms/iOS/Info.plist
+++ b/HelloMaui/Platforms/iOS/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CFBundleDisplayName</key>
+<string>HelloMaui</string>
+<key>CFBundleIdentifier</key>
+<string>com.companyname.hellomaui</string>
+<key>UILaunchStoryboardName</key>
+<string>MauiSplash</string>
+<key>UIRequiresPersistentWiFi</key>
+<false/>
+<key>LSRequiresIPhoneOS</key>
+<true/>
+<key>UIDeviceFamily</key>
+<array>
+<integer>1</integer>
+<integer>2</integer>
+</array>
+<key>UISupportedInterfaceOrientations</key>
+<array>
+<string>UIInterfaceOrientationPortrait</string>
+<string>UIInterfaceOrientationLandscapeLeft</string>
+<string>UIInterfaceOrientationLandscapeRight</string>
+</array>
+<key>UISupportedInterfaceOrientations~ipad</key>
+<array>
+<string>UIInterfaceOrientationPortrait</string>
+<string>UIInterfaceOrientationPortraitUpsideDown</string>
+<string>UIInterfaceOrientationLandscapeLeft</string>
+<string>UIInterfaceOrientationLandscapeRight</string>
+</array>
+</dict>
+</plist>

--- a/HelloMaui/Platforms/iOS/Program.cs
+++ b/HelloMaui/Platforms/iOS/Program.cs
@@ -1,0 +1,12 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace HelloMaui;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/HelloMaui/Resources/AppIcon/appicon.svg
+++ b/HelloMaui/Resources/AppIcon/appicon.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7030A0" />
+      <stop offset="100%" stop-color="#512BD4" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="120" fill="url(#gradient)" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Segoe UI" font-size="220" fill="#FFFFFF">HM</text>
+</svg>

--- a/HelloMaui/Resources/Splash/splash.svg
+++ b/HelloMaui/Resources/Splash/splash.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" fill="#512BD4" />
+  <circle cx="256" cy="256" r="160" fill="#FFFFFF" opacity="0.2" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Segoe UI" font-size="180" fill="#FFFFFF">HM</text>
+</svg>


### PR DESCRIPTION
## Summary
- enable Windows targeting when building from macOS or Linux so Windows assets compile

## Testing
- dotnet restore *(fails: `dotnet` command unavailable in container)*
- dotnet build -f net10.0-maccatalyst *(fails: `dotnet` command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca03410740832fb21a4e022d1e9a3c